### PR TITLE
Add Livewire toast notifications

### DIFF
--- a/app/Livewire/Toast.php
+++ b/app/Livewire/Toast.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class Toast extends Component
+{
+    public function render()
+    {
+        return view('livewire.toast');
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -5,6 +5,7 @@
         </h2>
     </x-slot>
 
+    <livewire:toast />
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg">

--- a/resources/views/livewire/toast.blade.php
+++ b/resources/views/livewire/toast.blade.php
@@ -1,0 +1,30 @@
+<div
+    x-data="{
+        toasts: [],
+        add(toast) {
+            toast.id = Date.now() + Math.random();
+            this.toasts.push(toast);
+            setTimeout(() => {
+                this.toasts = this.toasts.filter(t => t.id !== toast.id)
+            }, 3000);
+        }
+    }"
+    x-init="
+        window.addEventListener('toast', e => Livewire.dispatch('toast', e.detail));
+        Livewire.on('toast', toast => add(toast));
+    "
+    class="fixed top-4 right-4 flex flex-col space-y-2 z-50"
+>
+    <template x-for="toast in toasts" :key="toast.id">
+        <div
+            class="px-4 py-2 rounded shadow text-white"
+            :class="{
+                'bg-green-500': toast.type === 'success',
+                'bg-red-500': toast.type === 'error',
+                'bg-yellow-500': toast.type === 'warning',
+                'bg-blue-500': toast.type === 'info'
+            }"
+            x-text="toast.message"
+        ></div>
+    </template>
+</div>


### PR DESCRIPTION
## Summary
- add Livewire `toast` component to capture browser events and show auto dismissing toasts
- render toast component on dashboard

## Testing
- `composer test` *(fails: Database file at path [feednity_base] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689342cb927883278d333d4fc6cac5de