### PR TITLE
feat: add dashboard UI blade components

### DIFF
--- a/resources/views/components/dashboard/alert.blade.php
+++ b/resources/views/components/dashboard/alert.blade.php
@@ -1,0 +1,33 @@
+{{--
+    Dashboard Alert component
+
+    Usage:
+    <x-dashboard.alert type="success" size="md">
+        Operation successful.
+    </x-dashboard.alert>
+--}}
+@props([
+    'type' => 'info',
+    'size' => 'md'
+])
+
+@php
+$typeClasses = [
+    'success' => 'bg-green-100 border-green-400 text-green-700',
+    'danger' => 'bg-red-100 border-red-400 text-red-700',
+    'warning' => 'bg-yellow-100 border-yellow-400 text-yellow-700',
+    'info' => 'bg-blue-100 border-blue-400 text-blue-700',
+];
+
+$sizeClasses = [
+    'sm' => 'px-2 py-2 text-sm',
+    'md' => 'px-4 py-3',
+    'lg' => 'px-6 py-4 text-lg',
+];
+
+$classes = ($typeClasses[$type] ?? $typeClasses['info']) . ' ' . ($sizeClasses[$size] ?? $sizeClasses['md']);
+@endphp
+
+<div {{ $attributes->merge(['class' => 'border-l-4 rounded ' . $classes]) }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/dashboard/badge.blade.php
+++ b/resources/views/components/dashboard/badge.blade.php
@@ -1,0 +1,33 @@
+{{--
+    Dashboard Badge component
+
+    Usage:
+    <x-dashboard.badge type="info" size="sm">
+        New
+    </x-dashboard.badge>
+--}}
+@props([
+    'type' => 'info',
+    'size' => 'md'
+])
+
+@php
+$typeClasses = [
+    'info' => 'bg-blue-100 text-blue-800',
+    'success' => 'bg-green-100 text-green-800',
+    'warning' => 'bg-yellow-100 text-yellow-800',
+    'danger' => 'bg-red-100 text-red-800',
+];
+
+$sizeClasses = [
+    'sm' => 'text-xs px-2 py-0.5',
+    'md' => 'text-sm px-3 py-0.5',
+    'lg' => 'text-base px-4 py-1',
+];
+
+$classes = ($typeClasses[$type] ?? $typeClasses['info']) . ' ' . ($sizeClasses[$size] ?? $sizeClasses['md']);
+@endphp
+
+<span {{ $attributes->merge(['class' => 'inline-flex items-center font-semibold rounded ' . $classes]) }}>
+    {{ $slot }}
+</span>

--- a/resources/views/components/dashboard/card.blade.php
+++ b/resources/views/components/dashboard/card.blade.php
@@ -1,0 +1,41 @@
+{{--
+    Dashboard Card component
+
+    Usage:
+    <x-dashboard.card type="basic" size="md" color="white" class="mt-4">
+        Content goes here.
+    </x-dashboard.card>
+--}}
+@props([
+    'type' => 'basic',
+    'size' => 'md',
+    'color' => 'white'
+])
+
+@php
+$colorClasses = [
+    'white' => 'bg-white dark:bg-gray-800',
+    'gray' => 'bg-gray-100 dark:bg-gray-700',
+    'indigo' => 'bg-indigo-50 dark:bg-indigo-700',
+];
+
+$sizeClasses = [
+    'sm' => 'p-4',
+    'md' => 'p-6',
+    'lg' => 'p-8',
+];
+
+$typeClasses = [
+    'basic' => '',
+    'bordered' => 'border border-gray-200 dark:border-gray-600',
+    'hover' => 'transition hover:shadow-lg',
+];
+
+$classes = ($colorClasses[$color] ?? $colorClasses['white'])
+    . ' ' . ($sizeClasses[$size] ?? $sizeClasses['md'])
+    . ' rounded-lg shadow ' . ($typeClasses[$type] ?? $typeClasses['basic']);
+@endphp
+
+<div {{ $attributes->merge(['class' => $classes]) }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/dashboard/icon.blade.php
+++ b/resources/views/components/dashboard/icon.blade.php
@@ -1,0 +1,40 @@
+{{--
+    Dashboard Icon component
+
+    Usage:
+    <x-dashboard.icon name="check" size="md" color="green" class="mr-1" />
+--}}
+@props([
+    'name' => 'info',
+    'size' => 'md',
+    'color' => 'gray'
+])
+
+@php
+$paths = [
+    'check' => 'M5 13l4 4L19 7',
+    'x' => 'M6 18L18 6M6 6l12 12',
+    'info' => 'M13 16h-1v-4h-1m1-4h.01',
+];
+$path = $paths[$name] ?? $paths['info'];
+
+$sizeClasses = [
+    'sm' => 'h-4 w-4',
+    'md' => 'h-5 w-5',
+    'lg' => 'h-6 w-6',
+];
+$sizeClass = $sizeClasses[$size] ?? $sizeClasses['md'];
+
+$colorClasses = [
+    'gray' => 'text-gray-500',
+    'red' => 'text-red-500',
+    'green' => 'text-green-500',
+    'blue' => 'text-blue-500',
+];
+$colorClass = $colorClasses[$color] ?? $colorClasses['gray'];
+@endphp
+
+<svg {{ $attributes->merge(['class' => $sizeClass . ' ' . $colorClass]) }}
+     fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="{{ $path }}" />
+</svg>

--- a/resources/views/components/dashboard/modal.blade.php
+++ b/resources/views/components/dashboard/modal.blade.php
@@ -1,0 +1,57 @@
+{{--
+    Dashboard Modal component
+
+    Usage:
+    <x-dashboard.modal wire:model="showModal" maxWidth="xl" color="white">
+        <!-- Modal content -->
+    </x-dashboard.modal>
+--}}
+@props(['id' => null, 'maxWidth' => '2xl', 'color' => 'white'])
+
+@php
+$id = $id ?? md5($attributes->wire('model'));
+$maxWidthClass = [
+    'sm' => 'sm:max-w-sm',
+    'md' => 'sm:max-w-md',
+    'lg' => 'sm:max-w-lg',
+    'xl' => 'sm:max-w-xl',
+    '2xl' => 'sm:max-w-2xl',
+][$maxWidth] ?? 'sm:max-w-2xl';
+
+$backgrounds = [
+    'white' => 'bg-white dark:bg-gray-800',
+    'gray' => 'bg-gray-100 dark:bg-gray-700',
+    'indigo' => 'bg-indigo-50 dark:bg-indigo-700',
+];
+$backgroundClass = $backgrounds[$color] ?? $backgrounds['white'];
+@endphp
+
+<div
+    x-data="{ show: @entangle($attributes->wire('model')) }"
+    x-on:close.stop="show = false"
+    x-on:keydown.escape.window="show = false"
+    x-show="show"
+    id="{{ $id }}"
+    class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
+    style="display: none;"
+>
+    <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
+                    x-transition:enter-start="opacity-0"
+                    x-transition:enter-end="opacity-100"
+                    x-transition:leave="ease-in duration-200"
+                    x-transition:leave-start="opacity-100"
+                    x-transition:leave-end="opacity-0">
+        <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75"></div>
+    </div>
+
+    <div x-show="show" class="mb-6 {{ $backgroundClass }} rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidthClass }} sm:mx-auto"
+                    x-trap.inert.noscroll="show"
+                    x-transition:enter="ease-out duration-300"
+                    x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                    x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+                    x-transition:leave="ease-in duration-200"
+                    x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+                    x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+        {{ $slot }}
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add Tailwind/Jetstream-based dashboard card, alert, badge, modal and icon components with customizable attributes
- components auto-discovered under `resources/views/components/dashboard`

## Testing
- `php artisan test` *(fails: Database file at path [feednity_base] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689342c6839883279f956d0c61ce12bc