### PR TITLE
Add core feed and store schema

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Feed extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'store_id',
+        'name',
+        'channel',
+        'format',
+        'status',
+    ];
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function rules(): HasMany
+    {
+        return $this->hasMany(FeedRule::class);
+    }
+
+    public function runs(): HasMany
+    {
+        return $this->hasMany(FeedRun::class);
+    }
+
+    public function files(): HasMany
+    {
+        return $this->hasMany(FeedFile::class);
+    }
+}

--- a/app/Models/FeedFile.php
+++ b/app/Models/FeedFile.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FeedFile extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'feed_id',
+        'path',
+        'format',
+        'generated_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'generated_at' => 'datetime',
+        ];
+    }
+
+    public function feed(): BelongsTo
+    {
+        return $this->belongsTo(Feed::class);
+    }
+}

--- a/app/Models/FeedRule.php
+++ b/app/Models/FeedRule.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FeedRule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'feed_id',
+        'type',
+        'config',
+        'sort_order',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'config' => 'array',
+        ];
+    }
+
+    public function feed(): BelongsTo
+    {
+        return $this->belongsTo(Feed::class);
+    }
+}

--- a/app/Models/FeedRun.php
+++ b/app/Models/FeedRun.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FeedRun extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'feed_id',
+        'started_at',
+        'completed_at',
+        'success',
+        'log',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'started_at' => 'datetime',
+            'completed_at' => 'datetime',
+        ];
+    }
+
+    public function feed(): BelongsTo
+    {
+        return $this->belongsTo(Feed::class);
+    }
+}

--- a/app/Models/ProductCache.php
+++ b/app/Models/ProductCache.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProductCache extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'store_id',
+        'external_id',
+        'data',
+        'fetched_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'data' => 'array',
+            'fetched_at' => 'datetime',
+        ];
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+}

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Store extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'team_id',
+        'platform',
+        'name',
+        'domain',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+        ];
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function tokens(): HasMany
+    {
+        return $this->hasMany(StoreToken::class);
+    }
+
+    public function productCaches(): HasMany
+    {
+        return $this->hasMany(ProductCache::class);
+    }
+
+    public function feeds(): HasMany
+    {
+        return $this->hasMany(Feed::class);
+    }
+}

--- a/app/Models/StoreToken.php
+++ b/app/Models/StoreToken.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StoreToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'store_id',
+        'access_token',
+        'refresh_token',
+        'scopes',
+        'expires_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'scopes' => 'array',
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Team extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function stores(): HasMany
+    {
+        return $this->hasMany(Store::class);
+    }
+}

--- a/database/factories/FeedFactory.php
+++ b/database/factories/FeedFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Feed;
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Feed>
+ */
+class FeedFactory extends Factory
+{
+    protected $model = Feed::class;
+
+    public function definition(): array
+    {
+        return [
+            'store_id' => Store::factory(),
+            'name' => $this->faker->word(),
+            'channel' => $this->faker->word(),
+            'format' => $this->faker->randomElement(['xml', 'csv', 'json']),
+            'status' => 'active',
+        ];
+    }
+}

--- a/database/factories/FeedFileFactory.php
+++ b/database/factories/FeedFileFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Feed;
+use App\Models\FeedFile;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<FeedFile>
+ */
+class FeedFileFactory extends Factory
+{
+    protected $model = FeedFile::class;
+
+    public function definition(): array
+    {
+        return [
+            'feed_id' => Feed::factory(),
+            'path' => $this->faker->filePath(),
+            'format' => $this->faker->randomElement(['xml', 'csv', 'json']),
+            'generated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/FeedRuleFactory.php
+++ b/database/factories/FeedRuleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Feed;
+use App\Models\FeedRule;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<FeedRule>
+ */
+class FeedRuleFactory extends Factory
+{
+    protected $model = FeedRule::class;
+
+    public function definition(): array
+    {
+        return [
+            'feed_id' => Feed::factory(),
+            'type' => 'filter',
+            'config' => [],
+            'sort_order' => 1,
+        ];
+    }
+}

--- a/database/factories/FeedRunFactory.php
+++ b/database/factories/FeedRunFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Feed;
+use App\Models\FeedRun;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<FeedRun>
+ */
+class FeedRunFactory extends Factory
+{
+    protected $model = FeedRun::class;
+
+    public function definition(): array
+    {
+        $start = now();
+        return [
+            'feed_id' => Feed::factory(),
+            'started_at' => $start,
+            'completed_at' => $start->copy()->addMinutes(5),
+            'success' => true,
+            'log' => null,
+        ];
+    }
+}

--- a/database/factories/ProductCacheFactory.php
+++ b/database/factories/ProductCacheFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ProductCache;
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProductCache>
+ */
+class ProductCacheFactory extends Factory
+{
+    protected $model = ProductCache::class;
+
+    public function definition(): array
+    {
+        return [
+            'store_id' => Store::factory(),
+            'external_id' => (string) $this->faker->unique()->numberBetween(1, 100000),
+            'data' => ['title' => $this->faker->sentence()],
+            'fetched_at' => now(),
+        ];
+    }
+}

--- a/database/factories/StoreFactory.php
+++ b/database/factories/StoreFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Store;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Store>
+ */
+class StoreFactory extends Factory
+{
+    protected $model = Store::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'platform' => $this->faker->word(),
+            'name' => $this->faker->company(),
+            'domain' => $this->faker->domainName(),
+            'metadata' => [],
+        ];
+    }
+}

--- a/database/factories/StoreTokenFactory.php
+++ b/database/factories/StoreTokenFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Store;
+use App\Models\StoreToken;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<StoreToken>
+ */
+class StoreTokenFactory extends Factory
+{
+    protected $model = StoreToken::class;
+
+    public function definition(): array
+    {
+        return [
+            'store_id' => Store::factory(),
+            'access_token' => Str::random(32),
+            'refresh_token' => Str::random(32),
+            'scopes' => [],
+            'expires_at' => now()->addMonth(),
+        ];
+    }
+}

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Team>
+ */
+class TeamFactory extends Factory
+{
+    protected $model = Team::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+        ];
+    }
+}

--- a/database/migrations/2025_08_06_142746_create_teams_table.php
+++ b/database/migrations/2025_08_06_142746_create_teams_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/database/migrations/2025_08_06_142749_create_stores_table.php
+++ b/database/migrations/2025_08_06_142749_create_stores_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('stores', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('platform');
+            $table->string('name');
+            $table->string('domain')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('stores');
+    }
+};

--- a/database/migrations/2025_08_06_142753_create_store_tokens_table.php
+++ b/database/migrations/2025_08_06_142753_create_store_tokens_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('store_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('store_id')->constrained('stores')->cascadeOnDelete();
+            $table->string('access_token');
+            $table->string('refresh_token')->nullable();
+            $table->json('scopes')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('store_tokens');
+    }
+};

--- a/database/migrations/2025_08_06_142755_create_products_cache_table.php
+++ b/database/migrations/2025_08_06_142755_create_products_cache_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('products_cache', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('store_id')->constrained('stores')->cascadeOnDelete();
+            $table->string('external_id');
+            $table->json('data');
+            $table->timestamp('fetched_at');
+            $table->timestamps();
+
+            $table->unique(['store_id', 'external_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('products_cache');
+    }
+};

--- a/database/migrations/2025_08_06_142757_create_feeds_table.php
+++ b/database/migrations/2025_08_06_142757_create_feeds_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('feeds', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('store_id')->constrained('stores')->cascadeOnDelete();
+            $table->string('name');
+            $table->string('channel');
+            $table->string('format');
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('feeds');
+    }
+};

--- a/database/migrations/2025_08_06_142800_create_feed_rules_table.php
+++ b/database/migrations/2025_08_06_142800_create_feed_rules_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('feed_rules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('feed_id')->constrained('feeds')->cascadeOnDelete();
+            $table->string('type');
+            $table->json('config');
+            $table->integer('sort_order');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('feed_rules');
+    }
+};

--- a/database/migrations/2025_08_06_142802_create_feed_runs_table.php
+++ b/database/migrations/2025_08_06_142802_create_feed_runs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('feed_runs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('feed_id')->constrained('feeds')->cascadeOnDelete();
+            $table->timestamp('started_at');
+            $table->timestamp('completed_at')->nullable();
+            $table->boolean('success');
+            $table->text('log')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('feed_runs');
+    }
+};

--- a/database/migrations/2025_08_06_142805_create_feed_files_table.php
+++ b/database/migrations/2025_08_06_142805_create_feed_files_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('feed_files', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('feed_id')->constrained('feeds')->cascadeOnDelete();
+            $table->string('path');
+            $table->string('format');
+            $table->timestamp('generated_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('feed_files');
+    }
+};


### PR DESCRIPTION
## Summary
- scaffold teams, stores and tokens tables for shop connections
- add product cache, feeds, feed rules, runs and files tables
- stub eloquent models and factories with relationships

## Testing
- `php artisan migrate:fresh`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6893656f44688327b2bc3116f6b7f79d