### PR TITLE
feat: introduce shop adapter architecture

### DIFF
--- a/app/Adapters/Contracts/ShopAdapterInterface.php
+++ b/app/Adapters/Contracts/ShopAdapterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Adapters\Contracts;
+
+/**
+ * Unified contract for interacting with external shop platforms.
+ */
+interface ShopAdapterInterface
+{
+    /**
+     * Retrieve basic store metadata such as name, domain and timezone.
+     */
+    public function getStoreInfo(): array;
+
+    /**
+     * Retrieve a paginated list of products.
+     *
+     * @param int $limit Number of products per page.
+     * @param int $page  Page number starting from 1.
+     *
+     * @return array<int, array>
+     */
+    public function getProducts(int $limit = 100, int $page = 1): array;
+
+    /**
+     * Retrieve a single product by its external identifier.
+     */
+    public function getProductById(string $externalId): ?array;
+
+    /**
+     * Refresh the access token used for authenticating API calls.
+     */
+    public function refreshAccessToken(): void;
+}

--- a/app/Adapters/README.md
+++ b/app/Adapters/README.md
@@ -1,0 +1,29 @@
+# Shop Adapters
+
+This directory contains the adapter layer used to communicate with third-party
+shop platforms (e.g. Shopify, Magento, WooCommerce). Each adapter implements the
+[`ShopAdapterInterface`](Contracts/ShopAdapterInterface.php) providing a unified
+API for retrieving store information and products.
+
+## Usage
+
+```php
+use App\Adapters\ShopAdapterResolver;
+use App\Models\Store;
+
+$store = Store::find($id);
+$adapter = ShopAdapterResolver::resolve($store);
+
+$products = $adapter->getProducts(50, 1);
+$info = $adapter->getStoreInfo();
+```
+
+## Adding New Adapters
+
+1. Create a class in `app/Adapters/Shops` implementing
+   `ShopAdapterInterface`.
+2. Register it within `ShopAdapterResolver::resolve`.
+3. Provide tests mocking external API responses.
+
+Adapters for PrestaShop, Salesforce, and SAP are currently placeholders and
+should be completed in the future.

--- a/app/Adapters/ShopAdapterResolver.php
+++ b/app/Adapters/ShopAdapterResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Adapters;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Adapters\Shops\{MagentoAdapter, PrestaShopAdapter, SAPAdapter, SalesforceAdapter, ShopifyAdapter, ShopwareAdapter, WooCommerceAdapter};
+use App\Models\Store;
+
+/**
+ * Factory class responsible for resolving the correct adapter for a store.
+ */
+class ShopAdapterResolver
+{
+    public static function resolve(Store $store): ShopAdapterInterface
+    {
+        return match ($store->platform) {
+            'shopify' => new ShopifyAdapter($store),
+            'magento' => new MagentoAdapter($store),
+            'woocommerce' => new WooCommerceAdapter($store),
+            'shopware' => new ShopwareAdapter($store),
+            'prestashop' => new PrestaShopAdapter($store),
+            'salesforce' => new SalesforceAdapter($store),
+            'sap' => new SAPAdapter($store),
+            default => throw new \RuntimeException("Unsupported platform: {$store->platform}"),
+        };
+    }
+}

--- a/app/Adapters/Shops/MagentoAdapter.php
+++ b/app/Adapters/Shops/MagentoAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Adapters\Shops;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Models\Store;
+
+/**
+ * Adapter for Magento platform.
+ *
+ * TODO: Implement API calls and normalization logic.
+ */
+class MagentoAdapter implements ShopAdapterInterface
+{
+    public function __construct(protected Store $store)
+    {
+    }
+
+    public function getStoreInfo(): array
+    {
+        // TODO: Implement Magento store info retrieval
+        return [];
+    }
+
+    public function getProducts(int $limit = 100, int $page = 1): array
+    {
+        // TODO: Implement Magento product listing
+        return [];
+    }
+
+    public function getProductById(string $externalId): ?array
+    {
+        // TODO: Implement Magento single product retrieval
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+        // TODO: Implement Magento token refresh
+    }
+}

--- a/app/Adapters/Shops/PrestaShopAdapter.php
+++ b/app/Adapters/Shops/PrestaShopAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Adapters\Shops;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Models\Store;
+
+/**
+ * Dummy adapter for PrestaShop platform.
+ *
+ * TODO: Implement real PrestaShop integration.
+ */
+class PrestaShopAdapter implements ShopAdapterInterface
+{
+    public function __construct(protected Store $store)
+    {
+    }
+
+    public function getStoreInfo(): array
+    {
+        // TODO
+        return [];
+    }
+
+    public function getProducts(int $limit = 100, int $page = 1): array
+    {
+        // TODO
+        return [];
+    }
+
+    public function getProductById(string $externalId): ?array
+    {
+        // TODO
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+        // TODO
+    }
+}

--- a/app/Adapters/Shops/SAPAdapter.php
+++ b/app/Adapters/Shops/SAPAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Adapters\Shops;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Models\Store;
+
+/**
+ * Dummy adapter for SAP Commerce Cloud.
+ *
+ * TODO: Implement real SAP integration.
+ */
+class SAPAdapter implements ShopAdapterInterface
+{
+    public function __construct(protected Store $store)
+    {
+    }
+
+    public function getStoreInfo(): array
+    {
+        // TODO
+        return [];
+    }
+
+    public function getProducts(int $limit = 100, int $page = 1): array
+    {
+        // TODO
+        return [];
+    }
+
+    public function getProductById(string $externalId): ?array
+    {
+        // TODO
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+        // TODO
+    }
+}

--- a/app/Adapters/Shops/SalesforceAdapter.php
+++ b/app/Adapters/Shops/SalesforceAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Adapters\Shops;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Models\Store;
+
+/**
+ * Dummy adapter for Salesforce Commerce Cloud.
+ *
+ * TODO: Implement real Salesforce integration.
+ */
+class SalesforceAdapter implements ShopAdapterInterface
+{
+    public function __construct(protected Store $store)
+    {
+    }
+
+    public function getStoreInfo(): array
+    {
+        // TODO
+        return [];
+    }
+
+    public function getProducts(int $limit = 100, int $page = 1): array
+    {
+        // TODO
+        return [];
+    }
+
+    public function getProductById(string $externalId): ?array
+    {
+        // TODO
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+        // TODO
+    }
+}

--- a/app/Adapters/Shops/ShopifyAdapter.php
+++ b/app/Adapters/Shops/ShopifyAdapter.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Adapters\Shops;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Models\Store;
+use App\Models\StoreToken;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Arr;
+
+/**
+ * Adapter for Shopify platform using the Admin API.
+ */
+class ShopifyAdapter implements ShopAdapterInterface
+{
+    protected Store $store;
+
+    public function __construct(Store $store)
+    {
+        $this->store = $store;
+    }
+
+    /**
+     * Build the base API URL for the store.
+     */
+    protected function baseUrl(): string
+    {
+        return sprintf('https://%s/admin/api/2023-10', $this->store->domain);
+    }
+
+    /**
+     * Retrieve the most recent token associated with the store.
+     */
+    protected function token(): ?StoreToken
+    {
+        return $this->store->tokens()->latest()->first();
+    }
+
+    /**
+     * Perform an HTTP request against the Shopify API handling retries and errors.
+     */
+    protected function request(string $method, string $endpoint, array $params = []): array
+    {
+        $token = $this->token()?->access_token;
+
+        $response = Http::retry(3, 1000)
+            ->withToken($token)
+            ->$method($this->baseUrl() . $endpoint, $params);
+
+        if ($response->failed()) {
+            $response->throw();
+        }
+
+        return $response->json();
+    }
+
+    public function getStoreInfo(): array
+    {
+        $data = $this->request('get', '/shop.json');
+
+        $shop = $data['shop'] ?? [];
+
+        return [
+            'name' => $shop['name'] ?? null,
+            'domain' => $shop['domain'] ?? null,
+            'timezone' => $shop['timezone'] ?? null,
+        ];
+    }
+
+    public function getProducts(int $limit = 100, int $page = 1): array
+    {
+        $data = $this->request('get', '/products.json', [
+            'limit' => $limit,
+            'page' => $page,
+        ]);
+
+        return array_map(fn (array $product) => $this->normalizeProduct($product), $data['products'] ?? []);
+    }
+
+    public function getProductById(string $externalId): ?array
+    {
+        $data = $this->request('get', sprintf('/products/%s.json', $externalId));
+
+        return isset($data['product']) ? $this->normalizeProduct($data['product']) : null;
+    }
+
+    /**
+     * Normalize Shopify product structure to Feednity's internal representation.
+     */
+    protected function normalizeProduct(array $product): array
+    {
+        $variant = Arr::first($product['variants'] ?? []) ?? [];
+
+        return [
+            'id' => $product['id'] ?? null,
+            'title' => $product['title'] ?? null,
+            'sku' => $variant['sku'] ?? null,
+            'price' => $variant['price'] ?? null,
+        ];
+    }
+
+    public function refreshAccessToken(): void
+    {
+        $token = $this->token();
+
+        if (! $token || ! $token->refresh_token) {
+            return;
+        }
+
+        $response = Http::asForm()->post(sprintf('https://%s/admin/oauth/access_token', $this->store->domain), [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $token->refresh_token,
+            'client_id' => config('services.shopify.client_id'),
+            'client_secret' => config('services.shopify.client_secret'),
+        ]);
+
+        if ($response->failed()) {
+            $response->throw();
+        }
+
+        $data = $response->json();
+
+        $token->update([
+            'access_token' => $data['access_token'] ?? $token->access_token,
+            'expires_at' => isset($data['expires_in']) ? now()->addSeconds($data['expires_in']) : $token->expires_at,
+        ]);
+    }
+}

--- a/app/Adapters/Shops/ShopwareAdapter.php
+++ b/app/Adapters/Shops/ShopwareAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Adapters\Shops;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Models\Store;
+
+/**
+ * Adapter for Shopware platform.
+ *
+ * TODO: Implement Admin API integration.
+ */
+class ShopwareAdapter implements ShopAdapterInterface
+{
+    public function __construct(protected Store $store)
+    {
+    }
+
+    public function getStoreInfo(): array
+    {
+        // TODO: Implement Shopware store info retrieval
+        return [];
+    }
+
+    public function getProducts(int $limit = 100, int $page = 1): array
+    {
+        // TODO: Implement Shopware product listing
+        return [];
+    }
+
+    public function getProductById(string $externalId): ?array
+    {
+        // TODO: Implement Shopware single product retrieval
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+        // TODO: Implement Shopware token refresh
+    }
+}

--- a/app/Adapters/Shops/WooCommerceAdapter.php
+++ b/app/Adapters/Shops/WooCommerceAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Adapters\Shops;
+
+use App\Adapters\Contracts\ShopAdapterInterface;
+use App\Models\Store;
+
+/**
+ * Adapter for WooCommerce platform.
+ *
+ * TODO: Implement REST API calls with authentication.
+ */
+class WooCommerceAdapter implements ShopAdapterInterface
+{
+    public function __construct(protected Store $store)
+    {
+    }
+
+    public function getStoreInfo(): array
+    {
+        // TODO: Implement WooCommerce store info retrieval
+        return [];
+    }
+
+    public function getProducts(int $limit = 100, int $page = 1): array
+    {
+        // TODO: Implement WooCommerce product listing
+        return [];
+    }
+
+    public function getProductById(string $externalId): ?array
+    {
+        // TODO: Implement WooCommerce single product retrieval
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+        // WooCommerce typically uses basic auth or application tokens
+    }
+}

--- a/tests/Unit/Adapters/ShopifyAdapterTest.php
+++ b/tests/Unit/Adapters/ShopifyAdapterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Unit\Adapters;
+
+use App\Adapters\ShopAdapterResolver;
+use App\Models\Store;
+use App\Models\StoreToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ShopifyAdapterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_store_info(): void
+    {
+        $store = Store::factory()->create([
+            'platform' => 'shopify',
+            'domain' => 'example.myshopify.com',
+        ]);
+        StoreToken::factory()->for($store)->create();
+
+        Http::fake([
+            'https://example.myshopify.com/admin/api/2023-10/shop.json' => Http::response([
+                'shop' => [
+                    'name' => 'Demo Shop',
+                    'domain' => 'example.myshopify.com',
+                    'timezone' => 'UTC',
+                ],
+            ]),
+        ]);
+
+        $adapter = ShopAdapterResolver::resolve($store);
+        $info = $adapter->getStoreInfo();
+
+        $this->assertSame('Demo Shop', $info['name']);
+        $this->assertSame('example.myshopify.com', $info['domain']);
+        $this->assertSame('UTC', $info['timezone']);
+    }
+
+    public function test_get_products(): void
+    {
+        $store = Store::factory()->create([
+            'platform' => 'shopify',
+            'domain' => 'example.myshopify.com',
+        ]);
+        StoreToken::factory()->for($store)->create();
+
+        Http::fake([
+            'https://example.myshopify.com/admin/api/2023-10/products.json*' => Http::response([
+                'products' => [
+                    [
+                        'id' => 1,
+                        'title' => 'Test Product',
+                        'variants' => [
+                            ['sku' => 'SKU1', 'price' => '10.00'],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $adapter = ShopAdapterResolver::resolve($store);
+        $products = $adapter->getProducts(50, 1);
+
+        $this->assertCount(1, $products);
+        $this->assertSame('Test Product', $products[0]['title']);
+        $this->assertSame('SKU1', $products[0]['sku']);
+    }
+
+    public function test_get_product_by_id(): void
+    {
+        $store = Store::factory()->create([
+            'platform' => 'shopify',
+            'domain' => 'example.myshopify.com',
+        ]);
+        StoreToken::factory()->for($store)->create();
+
+        Http::fake([
+            'https://example.myshopify.com/admin/api/2023-10/products/123.json' => Http::response([
+                'product' => [
+                    'id' => 123,
+                    'title' => 'Single Product',
+                    'variants' => [
+                        ['sku' => 'SKU123', 'price' => '20.00'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $adapter = ShopAdapterResolver::resolve($store);
+        $product = $adapter->getProductById('123');
+
+        $this->assertSame('Single Product', $product['title']);
+        $this->assertSame('SKU123', $product['sku']);
+    }
+
+    public function test_refresh_access_token_updates_token(): void
+    {
+        config([
+            'services.shopify.client_id' => 'id',
+            'services.shopify.client_secret' => 'secret',
+        ]);
+
+        $store = Store::factory()->create([
+            'platform' => 'shopify',
+            'domain' => 'example.myshopify.com',
+        ]);
+        $token = StoreToken::factory()->for($store)->create([
+            'access_token' => 'old',
+            'refresh_token' => 'refresh',
+            'expires_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://example.myshopify.com/admin/oauth/access_token' => Http::response([
+                'access_token' => 'newtoken',
+                'expires_in' => 3600,
+            ]),
+        ]);
+
+        $adapter = ShopAdapterResolver::resolve($store);
+        $adapter->refreshAccessToken();
+
+        $token->refresh();
+        $this->assertSame('newtoken', $token->access_token);
+        $this->assertTrue($token->expires_at->greaterThan(now()));
+    }
+}


### PR DESCRIPTION
## Summary
- add unified `ShopAdapterInterface`
- implement Shopify adapter with product retrieval and token refresh
- scaffold adapters for other platforms and resolver
- document adapter usage and add unit tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6893cc66841c8327b0fe9b85f8ce3460