### PR TITLE
Add merchant onboarding with tenant context

### DIFF
--- a/app/Http/Controllers/OnboardingController.php
+++ b/app/Http/Controllers/OnboardingController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Team;
+use Illuminate\Http\Request;
+
+class OnboardingController extends Controller
+{
+    public function create()
+    {
+        return view('onboarding');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'team_name' => ['required', 'string', 'max:255'],
+            'store_name' => ['required', 'string', 'max:255'],
+            'gdpr_consent' => ['accepted'],
+        ]);
+
+        $team = Team::create(['name' => $validated['team_name']]);
+
+        $team->stores()->create([
+            'platform' => 'custom',
+            'name' => $validated['store_name'],
+            'gdpr_consented_at' => now(),
+        ]);
+
+        $request->session()->put('team_id', $team->id);
+
+        return redirect('/');
+    }
+}

--- a/app/Http/Middleware/SetTenant.php
+++ b/app/Http/Middleware/SetTenant.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Team;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+
+class SetTenant
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($teamId = $request->session()->get('team_id')) {
+            $team = Team::find($teamId);
+            if ($team) {
+                App::instance('tenant', $team);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -17,12 +17,14 @@ class Store extends Model
         'name',
         'domain',
         'metadata',
+        'gdpr_consented_at',
     ];
 
     protected function casts(): array
     {
         return [
             'metadata' => 'array',
+            'gdpr_consented_at' => 'datetime',
         ];
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,8 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Http\Middleware\SetTenant;
+use Illuminate\Session\Middleware\StartSession;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -11,7 +13,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->web(append: [StartSession::class, SetTenant::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'features' => [
+        'teams' => true,
+    ],
+];

--- a/database/migrations/2025_08_06_220112_add_gdpr_consented_at_to_stores_table.php
+++ b/database/migrations/2025_08_06_220112_add_gdpr_consented_at_to_stores_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stores', function (Blueprint $table) {
+            $table->timestamp('gdpr_consented_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('stores', function (Blueprint $table) {
+            $table->dropColumn('gdpr_consented_at');
+        });
+    }
+};

--- a/resources/views/onboarding.blade.php
+++ b/resources/views/onboarding.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Merchant Onboarding</title>
+</head>
+<body>
+    <form method="POST" action="/onboarding">
+        @csrf
+        <div>
+            <label>Team Name
+                <input type="text" name="team_name" value="{{ old('team_name') }}">
+            </label>
+            @error('team_name')<div>{{ $message }}</div>@enderror
+        </div>
+        <div>
+            <label>Store Name
+                <input type="text" name="store_name" value="{{ old('store_name') }}">
+            </label>
+            @error('store_name')<div>{{ $message }}</div>@enderror
+        </div>
+        <div>
+            <label>
+                <input type="checkbox" name="gdpr_consent" value="1"> I agree to the EU GDPR terms
+            </label>
+            @error('gdpr_consent')<div>{{ $message }}</div>@enderror
+        </div>
+        <button type="submit">Get Started</button>
+    </form>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\OnboardingController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/onboarding', [OnboardingController::class, 'create']);
+Route::post('/onboarding', [OnboardingController::class, 'store']);

--- a/tests/Feature/OnboardingTest.php
+++ b/tests/Feature/OnboardingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Tests\TestCase;
+
+class OnboardingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(ValidateCsrfToken::class);
+    }
+
+    public function test_merchants_must_consent_to_gdpr(): void
+    {
+        $response = $this->post('/onboarding', [
+            'team_name' => 'Acme',
+            'store_name' => 'Acme Store',
+        ]);
+
+        $response->assertSessionHasErrors('gdpr_consent');
+    }
+
+    public function test_onboarding_creates_team_and_sets_tenant_context(): void
+    {
+        $response = $this->post('/onboarding', [
+            'team_name' => 'Acme',
+            'store_name' => 'Acme Store',
+            'gdpr_consent' => '1',
+        ]);
+
+        $response->assertRedirect('/');
+
+        $team = Team::first();
+        $this->assertNotNull($team);
+        $this->assertEquals('Acme', $team->name);
+        $this->assertNotNull($team->stores()->first()->gdpr_consented_at);
+
+        $this->get('/');
+        $this->assertTrue(app()->bound('tenant'));
+        $this->assertEquals($team->id, app('tenant')->id);
+    }
+}


### PR DESCRIPTION
## Summary
- enable Jetstream team features
- add merchant onboarding flow with GDPR consent
- apply tenant context across requests via middleware

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6893d00372888327b99c14be466f6863