### PR TITLE
Add authenticated WooCommerce product retrieval

### DIFF
--- a/app/Adapters/Shops/WooCommerceAdapter.php
+++ b/app/Adapters/Shops/WooCommerceAdapter.php
@@ -4,6 +4,8 @@ namespace App\Adapters\Shops;
 
 use App\Adapters\Contracts\ShopAdapterInterface;
 use App\Models\Store;
+use App\Models\StoreToken;
+use Illuminate\Support\Facades\Http;
 
 /**
  * Adapter for WooCommerce platform.
@@ -16,22 +18,85 @@ class WooCommerceAdapter implements ShopAdapterInterface
     {
     }
 
+    /**
+     * Build the base URL for WooCommerce API.
+     */
+    protected function baseUrl(): string
+    {
+        return sprintf('https://%s/wp-json/wc/v3', $this->store->domain);
+    }
+
+    /**
+     * Retrieve latest credentials for the store.
+     */
+    protected function token(): ?StoreToken
+    {
+        if ($this->store->relationLoaded('tokens')) {
+            return $this->store->getRelation('tokens')->sortByDesc('id')->first();
+        }
+
+        return $this->store->tokens()->latest()->first();
+    }
+
+    /**
+     * Perform an authenticated request against the WooCommerce API.
+     */
+    protected function request(string $method, string $endpoint, array $params = []): array
+    {
+        $token = $this->token();
+        $key = $token?->access_token;
+        $secret = $token?->refresh_token;
+
+        $response = Http::retry(3, 1000)
+            ->withBasicAuth($key, $secret)
+            ->$method($this->baseUrl() . $endpoint, $params);
+
+        if ($response->failed()) {
+            $response->throw();
+        }
+
+        return $response->json();
+    }
+
     public function getStoreInfo(): array
     {
-        // TODO: Implement WooCommerce store info retrieval
-        return [];
+        $data = $this->request('get', '');
+
+        return [
+            'name' => $data['name'] ?? null,
+            'domain' => $data['url'] ?? $this->store->domain,
+            'timezone' => $data['timezone'] ?? null,
+        ];
     }
 
     public function getProducts(int $limit = 100, int $page = 1): array
     {
-        // TODO: Implement WooCommerce product listing
-        return [];
+        $data = $this->request('get', '/products', [
+            'per_page' => $limit,
+            'page' => $page,
+        ]);
+
+        return array_map(fn (array $product) => $this->normalizeProduct($product), $data);
     }
 
     public function getProductById(string $externalId): ?array
     {
-        // TODO: Implement WooCommerce single product retrieval
-        return null;
+        $data = $this->request('get', sprintf('/products/%s', $externalId));
+
+        return $data ? $this->normalizeProduct($data) : null;
+    }
+
+    /**
+     * Normalize WooCommerce product structure to Feednity's format.
+     */
+    protected function normalizeProduct(array $product): array
+    {
+        return [
+            'id' => $product['id'] ?? null,
+            'title' => $product['name'] ?? null,
+            'sku' => $product['sku'] ?? null,
+            'price' => $product['price'] ?? null,
+        ];
     }
 
     public function refreshAccessToken(): void

--- a/tests/Unit/Adapters/WooCommerceAdapterTest.php
+++ b/tests/Unit/Adapters/WooCommerceAdapterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Adapters;
+
+use App\Adapters\ShopAdapterResolver;
+use App\Models\Store;
+use App\Models\StoreToken;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class WooCommerceAdapterTest extends TestCase
+{
+    public function test_get_products(): void
+    {
+        $store = new Store(['platform' => 'woocommerce', 'domain' => 'example.com']);
+        $token = new StoreToken(['access_token' => 'ck_123', 'refresh_token' => 'cs_456']);
+        $store->setRelation('tokens', collect([$token]));
+
+        Http::fake([
+            'https://example.com/wp-json/wc/v3/products*' => Http::response([
+                [
+                    'id' => 1,
+                    'name' => 'Test Product',
+                    'sku' => 'SKU1',
+                    'price' => '10.00',
+                ],
+            ]),
+        ]);
+
+        $adapter = ShopAdapterResolver::resolve($store);
+        $products = $adapter->getProducts(50, 2);
+
+        $this->assertCount(1, $products);
+        $this->assertSame('Test Product', $products[0]['title']);
+        $this->assertSame('SKU1', $products[0]['sku']);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://example.com/wp-json/wc/v3/products?per_page=50&page=2'
+                && $request->hasHeader('Authorization', 'Basic ' . base64_encode('ck_123:cs_456'));
+        });
+    }
+
+    public function test_get_product_by_id(): void
+    {
+        $store = new Store(['platform' => 'woocommerce', 'domain' => 'example.com']);
+        $token = new StoreToken(['access_token' => 'ck_123', 'refresh_token' => 'cs_456']);
+        $store->setRelation('tokens', collect([$token]));
+
+        Http::fake([
+            'https://example.com/wp-json/wc/v3/products/123' => Http::response([
+                'id' => 123,
+                'name' => 'Single Product',
+                'sku' => 'SKU123',
+                'price' => '20.00',
+            ]),
+        ]);
+
+        $adapter = ShopAdapterResolver::resolve($store);
+        $product = $adapter->getProductById('123');
+
+        $this->assertSame('Single Product', $product['title']);
+        $this->assertSame('SKU123', $product['sku']);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://example.com/wp-json/wc/v3/products/123'
+                && $request->hasHeader('Authorization', 'Basic ' . base64_encode('ck_123:cs_456'));
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement WooCommerce adapter with authenticated REST calls
- support product listing and single product lookup
- add unit tests for WooCommerce adapter

## Testing
- `vendor/bin/phpunit tests/Unit/Adapters/WooCommerceAdapterTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689684367970832796c564b9fcdd88d3